### PR TITLE
Fix the app route

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
     <navigations>
         <navigation>
             <name>Skeleton App</name>
-            <route>skeletonapp.page.index</route>
+            <route>skeleton_app.page.index</route>
         </navigation>
     </navigations>
 </info>


### PR DESCRIPTION
Fixed the app navigation route for which earlier href was not getting generated for the skeleton_app icon.